### PR TITLE
Add an option to update an existing macro

### DIFF
--- a/texresults2.ado
+++ b/texresults2.ado
@@ -82,14 +82,21 @@ if "`action'"=="update"{
 			loc toreplace = substr("`linetoreplace'", 14, .) //extract the substring that starts with the macro (but not the part with backslashes)
         }
         file read texresultsfile line
-        }
+    }
     file close texresultsfile
-	
-	loc usingpath : word 2 of `using'
-	tempfile tmptex
-	copy `usingpath' `tmptex', public text replace
-	loc outpt = substr("`texmacro'}{`output'`xspace'}", 2, .) //remove leading backslash
-	filefilter `tmptex' `usingpath', from("`toreplace'") to(`outpt') replace	
+
+	if "`linetoreplace'" != "" { //if the line with the macro was found
+		loc usingpath : word 2 of `using'
+		tempfile tmptex
+		copy `usingpath' `tmptex', public text replace
+		loc outpt = substr("`texmacro'}{`output'`xspace'}", 2, .) //remove leading backslash
+		filefilter `tmptex' `usingpath', from("`toreplace'") to(`outpt') replace
+	}
+	else { //did not find the line with macro -> append
+		file open texresultsfile `using', write append
+		file write texresultsfile "\newcommand{`texmacro'}{`output'`xspace'}" _n
+		file close texresultsfile
+	}
 }
 
 else {

--- a/texresults2.ado
+++ b/texresults2.ado
@@ -71,12 +71,8 @@ else if inlist("`mathmode'", "off", "OFF", "Off") local output "`result'"
 
 ********************************************************************************
 *Create or modify macros file.
-tempfile tmptex
 
-loc usingpath : word 2 of `using'
-mac lis _usingpath
 if "`action'"=="update"{
-	copy `usingpath' `tmptex', public text replace
 	loc length_todetect = strlen("\newcommand{`texmacro'}{") // to identify the line the macro is on
     file open texresultsfile `using', read text
     file read texresultsfile line
@@ -88,6 +84,10 @@ if "`action'"=="update"{
         file read texresultsfile line
         }
     file close texresultsfile
+	
+	loc usingpath : word 2 of `using'
+	tempfile tmptex
+	copy `usingpath' `tmptex', public text replace
 	loc outpt = substr("`texmacro'}{`output'`xspace'}", 2, .) //remove leading backslash
 	filefilter `tmptex' `usingpath', from("`toreplace'") to(`outpt') replace	
 }

--- a/texresults2.ado
+++ b/texresults2.ado
@@ -3,12 +3,11 @@ This do-file defines "texresults2", a variant of "texresults" (Alvaro Carril) th
 has an option to suppress the $ signs.
 */
 
-
 program define texresults2
 syntax [using], ///
 	TEXmacro(string) ///
 	[ ///
-		replace Append ///
+		replace Append Update ///
 		Result(string) coef(varname) se(varname) tstat(varname) pvalue(varname) ///
 		mathmode(string) /// Can be either "on" or "off".
 		ROund(real 0.01) UNITzero XSpace ///
@@ -19,12 +18,12 @@ syntax [using], ///
 *Initial checks and processing.
 
 *Parse file action.
-if !missing("`replace'") & !missing("`append'") {
-	di as error "{bf:replace} and {bf:append} may not be specified simultaneously"
+local action `replace' `append' `update'
+local len_action : word count `action'
+if `len_action'>1 {
+	di as error "Specify only one of {bf:replace}, {bf:append}, and {bf:update}"
 	exit 198
 }
-local action `replace' `append'
-
 *Add backslash to macroname and issue warning if doesn't contain only alph.
 local isalph = regexm("`texmacro'","^[a-zA-Z ]*$")
 local texmacro = "\" + "`texmacro'"
@@ -32,7 +31,7 @@ if `isalph' == 0 di as text `""`texmacro'" may not be a valid LaTeX macro name"'
 
 if !missing("`xspace'") local xspace = "\" + "`xspace'"
 
-display "opcion: `xspace'"
+// display "opcion: `xspace'"
 
 
 ********************************************************************************
@@ -72,11 +71,33 @@ else if inlist("`mathmode'", "off", "OFF", "Off") local output "`result'"
 
 ********************************************************************************
 *Create or modify macros file.
-file open texresultsfile `using', write `action'
-file write texresultsfile "\newcommand{`texmacro'}{`output'`xspace'}" _n
-file close texresultsfile
+tempfile tmptex
 
-*display as text `" Open {browse results.txt}"'
+loc usingpath : word 2 of `using'
+mac lis _usingpath
+if "`action'"=="update"{
+	copy `usingpath' `tmptex', public text replace
+	loc length_todetect = strlen("\newcommand{`texmacro'}{") // to identify the line the macro is on
+    file open texresultsfile `using', read text
+    file read texresultsfile line
+    while r(eof)==0 {
+        if substr(`"`line'"',1,`length_todetect')=="\newcommand{`texmacro'}{" {
+			loc linetoreplace `line'
+			loc toreplace = substr("`linetoreplace'", 14, .) //extract the substring that starts with the macro (but not the part with backslashes)
+        }
+        file read texresultsfile line
+        }
+    file close texresultsfile
+	loc outpt = substr("`texmacro'}{`output'`xspace'}", 2, .) //remove leading backslash
+	filefilter `tmptex' `usingpath', from("`toreplace'") to(`outpt') replace	
+}
 
+else {
+	file open texresultsfile `using', write `action'
+	file write texresultsfile "\newcommand{`texmacro'}{`output'`xspace'}" _n
+	file close texresultsfile
+}
 
 end
+
+


### PR DESCRIPTION
If the user specifies `update` instead of `append`, the existing macro will be overwritten if it already exists or appended if it did not already exist.